### PR TITLE
Fix flutter beta error regarding MenuItem import

### DIFF
--- a/lib/src/tray_manager.dart
+++ b/lib/src/tray_manager.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:ui';
-import 'package:flutter/material.dart';
 import 'package:path/path.dart' as path;
 import 'package:uuid/uuid.dart';
 


### PR DESCRIPTION
There is an error when using this library with the most recent flutter beta (2.13.0-0.1.pre) which can be fixed by simply removing an unused import of `material.dart`.

```
The name 'MenuItem' is defined in the libraries 'package:flutter/src/widgets/platform_menu_bar.dart' and 
'package:tray_manager/src/menu_item.dart (via package:tray_manager/tray_manager.dart)'
```

An easy way for client code to fix this is to hide the `MenuItem` import from material if this is not needed.
```
import 'package:flutter/material.dart' hide MenuItem;
```

Basically the MenuItem class name collides with a new class in flutter which was added in [this commit](https://github.com/flutter/flutter/commit/2d9ad2608666ffe900684cefc14996da6dfa9ada). There is some mentions of the plans for flutter to add native menu bar support in the [flutter roadmap](https://github.com/flutter/flutter/wiki/Roadmap#:~:text=For%20desktop%20and%20web%20we%20will%20provide%20a%20solution%20for%20menus%20(context%20menus%20and%20menu%20bars)%2C%20including%20integration%20with%20the%20host%20OS%20(which%20is%20particularly%20relevant%20for%20macOS).) which can be read more about in this ticket https://github.com/flutter/flutter/issues/23600.



