### PR TITLE
Fix libayatana set icon deprecation

### DIFF
--- a/linux/tray_manager_plugin.cc
+++ b/linux/tray_manager_plugin.cc
@@ -123,7 +123,7 @@ static FlMethodResponse* set_icon(TrayManagerPlugin* self, FlValue* args) {
   }
 
   app_indicator_set_status(indicator, APP_INDICATOR_STATUS_ACTIVE);
-  app_indicator_set_icon(indicator, icon_path);
+  app_indicator_set_icon_full(indicator, icon_path, "");
 
   return FL_METHOD_RESPONSE(
       fl_method_success_response_new(fl_value_new_bool(true)));


### PR DESCRIPTION
With libayatana-appindicator 0.5.93 building my app fails with `linux/flutter/ephemeral/.plugin_symlinks/tray_manager/linux/tray_manager_plugin.cc:126:3: error: 'app_indicator_set_icon' is deprecated: Use app_indicator_set_icon_full instead [-Werror,-Wdeprecated-declarations]`.
I'm not sure why this only happens now since I checked the changelog and there was nothing suspicious.
The option has been deprecated for 13 years and the new method is also there since then, so it's safe to migrate.