### PR TITLE
fix(linux): ensure icon works in sandboxed environments

### DIFF
--- a/lib/src/helpers/sandbox.dart
+++ b/lib/src/helpers/sandbox.dart
@@ -1,0 +1,7 @@
+import 'dart:io';
+
+/// Returns `true` if the app is running in a sandbox, eg. Flatpak or Snap.
+bool runningInSandbox() {
+  return Platform.environment.containsKey('FLATPAK_ID') ||
+      Platform.environment.containsKey('SNAP');
+}

--- a/lib/src/tray_manager.dart
+++ b/lib/src/tray_manager.dart
@@ -95,9 +95,6 @@ class TrayManager {
     bool isTemplate = false, // macOS only
     TrayIconPositon iconPosition = TrayIconPositon.left, // macOS only
   }) async {
-    ByteData imageData = await rootBundle.load(iconPath);
-    String base64Icon = base64Encode(imageData.buffer.asUint8List());
-
     final Map<String, dynamic> arguments = {
       "id": shortid.generate(),
       'iconPath': path.joinAll([
@@ -105,10 +102,21 @@ class TrayManager {
         'data/flutter_assets',
         iconPath,
       ]),
-      'base64Icon': base64Icon,
       'isTemplate': isTemplate,
       'iconPosition': iconPosition.name,
     };
+
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.macOS:
+        // Add the icon as base64 string
+        ByteData imageData = await rootBundle.load(iconPath);
+        String base64Icon = base64Encode(imageData.buffer.asUint8List());
+        arguments['base64Icon'] = base64Icon;
+        break;
+      default:
+        break;
+    }
+
     await _channel.invokeMethod('setIcon', arguments);
   }
 


### PR DESCRIPTION
When running in a sandboxed environment, such as a Flatpak or Snap, the icon should be passed as the icon name, not a path.

This is required because when running in a sandbox, paths are not the same as seen by the app and the host system.