### PR TITLE
Add notes to the code comments of setToolTip

### DIFF
--- a/lib/src/tray_manager.dart
+++ b/lib/src/tray_manager.dart
@@ -153,6 +153,12 @@ class TrayManager {
   }
 
   /// Sets the hover text for this tray icon.
+  ///
+  /// Must be called after the icon is set.
+  /// ```dart
+  /// await trayManager.setIcon(...);
+  /// await trayManager.setToolTip(...);
+  /// ```
   Future<void> setToolTip(String toolTip) async {
     final Map<String, dynamic> arguments = {
       'toolTip': toolTip,


### PR DESCRIPTION
If `SetToolTip` is called before `SetIcon`, the tooltip will not be displayed. It is necessary to make this clear in the function comments.