### PR TITLE
docs: add "path" to use Git package correctly

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -85,6 +85,7 @@ dependencies:
     git:
       url: https://github.com/leanflutter/tray_manager.git
       ref: main
+      path: packages/tray_manager
 ```
 
 #### Linux requirements

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ dependencies:
     git:
       url: https://github.com/leanflutter/tray_manager.git
       ref: main
+      path: packages/tray_manager
 ```
 
 #### Linux requirements


### PR DESCRIPTION
The structure of this repository has been changed since 3f80df0aa9b5474f61d7fcb3830cced7bd5861fb. Without the "path" argument, we will get an error:

```console
$ flutter pub get; echo $?
Resolving dependencies... (1.8s)
Error on line 1, column 7: "name" field doesn't match expected name "tray_manager".
  ╷
1 │ name: tray_manager_workspace
  │       ^^^^^^^^^^^^^^^^^^^^^^
  ╵
Failed to update packages.
65

```

Reference: [Git packages § Package dependencies | Dart](https://dart.dev/tools/pub/dependencies#git-packages)