### PR TITLE
docs: solve issues by using GNOME AppIndicator

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -66,6 +66,10 @@ dependencies:
 
 2. 使用 [protocol_handler](https://github.com/leanflutter/protocol_handler) 包代替 `app_links` 包。
 
+### 在 GNOME 中不显示
+
+在使用 GNOME 桌面时, 可能需要安装 [AppIndicator](https://github.com/ubuntu/gnome-shell-extension-appindicator) 扩展以显示图标。
+
 ## 快速开始
 
 ### 安装

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ dependencies:
 
 2. Use [protocol_handler](https://github.com/leanflutter/protocol_handler) package instead of `app_links` package.
 
+### Not Showing in GNOME
+
+In GNOME desktop environment, the [AppIndicator](https://github.com/ubuntu/gnome-shell-extension-appindicator) extension may be required to display the icon.
+
 ## Quick Start
 
 ### Installation


### PR DESCRIPTION
I found the "[AppIndicator](https://github.com/ubuntu/gnome-shell-extension-appindicator)" extension when testing another project on Debian 12. Maybe new GNOME on newer distros shows the icon normally, but those old but still-supported distros should not be forgot.

Ref: 恢复 GNOME 顶栏的托盘图标 | Linux 中国 https://linux.cn/article-13785-1.html, https://linux.net.cn/article-13785-1.html, https://mp.weixin.qq.com/s/gqXATcAp7qDlrClL21iBXQ, https://zhuanlan.zhihu.com/p/410500061