### PR TITLE
bugfix/on-tray-icon-right-mouse-up: emit onTrayIconRightMouseUp on WM…

### DIFF
--- a/packages/tray_manager/windows/tray_manager_plugin.cpp
+++ b/packages/tray_manager/windows/tray_manager_plugin.cpp
@@ -193,7 +193,7 @@ std::optional<LRESULT> TrayManagerPlugin::HandleWindowProc(HWND hWnd,
                               std::make_unique<flutter::EncodableValue>());
         break;
       case WM_RBUTTONUP:
-        channel->InvokeMethod("onTrayIconRightMouseDown",
+        channel->InvokeMethod("onTrayIconRightMouseUp",
                               std::make_unique<flutter::EncodableValue>());
         break;
       default:


### PR DESCRIPTION
What’s changed?
In tray_manager_plugin.cpp, the case for WM_RBUTTONUP now invokes
onTrayIconRightMouseUp rather than onTrayIconRightMouseDown.

Why?
The “right mouse down” callback was misleading: context menus should
appear on mouse-up, and downstream code already expected an “Up”
event. This aligns the native behavior with the Dart API.

Testing:
Verified on Windows that right‐click on the tray icon now fires
onTrayIconRightMouseUp exactly once, allowing the context menu to
appear correctly.

Closes #57