### PR TITLE
Fix tray menus won't show up after spawning sub window on Windows

### DIFF
--- a/packages/tray_manager/windows/tray_manager_plugin.cpp
+++ b/packages/tray_manager/windows/tray_manager_plugin.cpp
@@ -89,9 +89,18 @@ class TrayManagerPlugin : public flutter::Plugin {
       std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
 };
 
+static bool plugin_already_registered = false;
+
 // static
 void TrayManagerPlugin::RegisterWithRegistrar(
     flutter::PluginRegistrarWindows* registrar) {
+  if (plugin_already_registered) {
+    // Skip registration in subwindow
+    return;
+  }
+  
+  plugin_already_registered = true;
+  
   channel = std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
       registrar->messenger(), "tray_manager",
       &flutter::StandardMethodCodec::GetInstance());


### PR DESCRIPTION
Fix for the tray icon not showing any menu or responding to actions when clicked after spawning a subwindow using packages like `window_manager_plus` or `desktop_multi_window`, by preventing the plugin from being registered multiple times after creating a window.