### PR TITLE
fix: Windows tray icon disappearing after sleep/wake cycles

### DIFF
--- a/packages/tray_manager/windows/tray_manager_plugin.cpp
+++ b/packages/tray_manager/windows/tray_manager_plugin.cpp
@@ -214,6 +214,21 @@ std::optional<LRESULT> TrayManagerPlugin::HandleWindowProc(HWND hWnd,
       tray_icon_setted = false;
       _ApplyIcon();
     }
+  } else if (message == WM_POWERBROADCAST) {
+    // Handle power management events (sleep/wake)
+    switch (wParam) {
+      case PBT_APMRESUMEAUTOMATIC:
+      case PBT_APMRESUMESUSPEND:
+        // System is resuming from sleep/hibernation
+        if (tray_icon_setted) {
+          // Restore the tray icon after system wakes up
+          tray_icon_setted = false;
+          _ApplyIcon();
+        }
+        break;
+      default:
+        break;
+    }
   }
   return result;
 }


### PR DESCRIPTION
After sleep on Windows, the tray icon disappears. It can be reproduced directly by running `kill -n explorer` in PowerShell