### PR TITLE
fix(macos): avoid tray redraws

### DIFF
--- a/packages/tray_manager/macos/Classes/TrayIcon.swift
+++ b/packages/tray_manager/macos/Classes/TrayIcon.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 //
 //  TrayIcon.swift
 //  tray_manager
@@ -13,14 +14,88 @@ public class TrayIcon: NSView {
     
     var statusItem: NSStatusItem?
     
+    var textAttributes: [NSAttributedString.Key : Any]?
+    
+    private let imageView: NSImageView = {
+        let iv = NSImageView()
+        iv.imageScaling = .scaleProportionallyDown
+        iv.isHidden = true
+        iv.setContentHuggingPriority(.required, for: .horizontal)
+        return iv
+    }()
+    
+    private let textField: NSTextField = {
+        let field = NSTextField()
+        field.isEditable = false
+        field.isBezeled = false
+        field.isHidden = true
+        field.drawsBackground = false
+        field.cell?.wraps = false
+        field.alignment = .right
+        return field
+    }()
+    
+    private let stackView: NSStackView = {
+        let stack = NSStackView()
+        stack.orientation = .horizontal
+        stack.spacing = 6
+        stack.distribution = .equalSpacing
+        return stack
+    }()
+    
+    
     public init() {
         super.init(frame: NSRect.zero)
         statusItem = NSStatusBar.system.statusItem(withLength:NSStatusItem.variableLength)
-        statusItem?.button?.addSubview(self)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.maximumLineHeight = 9
+        paragraphStyle.minimumLineHeight = 9
+        paragraphStyle.alignment = .right
+        paragraphStyle.lineBreakMode = .byClipping
+        
+        textAttributes = [
+            .paragraphStyle: paragraphStyle,
+            .font: NSFont.systemFont(ofSize: 8.75),
+            .foregroundColor: NSColor.labelColor
+        ]
+        
+        if let button = statusItem?.button {
+            button.addSubview(self)
+            self.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                self.leadingAnchor.constraint(equalTo: button.leadingAnchor),
+                self.trailingAnchor.constraint(equalTo: button.trailingAnchor),
+                self.topAnchor.constraint(equalTo: button.topAnchor),
+                self.bottomAnchor.constraint(equalTo: button.bottomAnchor),
+                self.heightAnchor.constraint(equalToConstant: NSStatusBar.system.thickness),
+            ])
+            setupView()
+        }
     }
+    
+    private func setupView() {
+        addSubview(stackView)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor,constant: 8),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor,constant: -8),
+            stackView.topAnchor.constraint(equalTo: topAnchor,constant:2),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor,constant:-2),
+        ])
+        
+        stackView.addArrangedSubview(imageView)
+        stackView.addArrangedSubview(textField)
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            textField.widthAnchor.constraint(equalToConstant: 42),
+            textField.trailingAnchor.constraint(equalTo:stackView.trailingAnchor),
+        ])
+    }
+    
     
     override init(frame frameRect: NSRect) {
         super.init(frame:frameRect);
+        setupView()
     }
     
     required init?(coder: NSCoder) {
@@ -28,19 +103,14 @@ public class TrayIcon: NSView {
     }
     
     public func setImage(_ image: NSImage, _ imagePosition: String) {
+        imageView.image = image
+        imageView.isHidden = false
         if let button = statusItem?.button {
-            button.image = image
-            setImagePosition(imagePosition)
+            button.sizeToFit()
         }
-
-
-        self.frame = statusItem!.button!.frame
     }
     
     public func setImagePosition(_ imagePosition: String) {
-        if let button = statusItem?.button {
-            button.imagePosition = imagePosition == "right" ? NSControl.ImagePosition.imageRight : NSControl.ImagePosition.imageLeft
-        }
         self.frame = statusItem!.button!.frame
     }
     
@@ -50,10 +120,11 @@ public class TrayIcon: NSView {
     }
     
     public func setTitle(_ title: String) {
+        textField.attributedStringValue = NSAttributedString(string: title, attributes: textAttributes)
+        textField.isHidden = title.isEmpty
         if let button = statusItem?.button {
-            button.title  = title
+            button.sizeToFit()
         }
-        self.frame = statusItem!.button!.frame
     }
     
     public func setToolTip(_ toolTip: String) {

--- a/packages/tray_manager/macos/Classes/TrayManagerPlugin.swift
+++ b/packages/tray_manager/macos/Classes/TrayManagerPlugin.swift
@@ -24,11 +24,11 @@ extension NSRect {
 public class TrayManagerPlugin: NSObject, FlutterPlugin, NSMenuDelegate {
     var channel: FlutterMethodChannel!
     
-    var trayIcon: TrayIcon?
+    var statusItem: NSStatusItem?
     var trayMenu: TrayMenu?
-    //    var statusItem: NSStatusItem = NSStatusItem();
-    
-    var _inited: Bool = false;
+    var iconPosition: NSControl.ImagePosition = .imageLeft
+    var lastTitle: String = ""
+    var textAttributes: [NSAttributedString.Key : Any]?
     
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "tray_manager", binaryMessenger: registrar.messenger)
@@ -102,20 +102,63 @@ public class TrayManagerPlugin: NSObject, FlutterPlugin, NSMenuDelegate {
             channel.invokeMethod(methodName!, arguments: nil, result: nil)
         }
     }
+
+    private func ensureStatusItem() {
+        if statusItem != nil {
+            return
+        }
+        statusItem = NSStatusBar.system.statusItem(withLength:NSStatusItem.variableLength)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.maximumLineHeight = 9
+        paragraphStyle.minimumLineHeight = 9
+        paragraphStyle.alignment = .right
+        paragraphStyle.lineBreakMode = .byClipping
+        textAttributes = [
+            .paragraphStyle: paragraphStyle,
+            .font: NSFont.systemFont(ofSize: 8.75),
+            .foregroundColor: NSColor.labelColor
+        ]
+        if let button = statusItem?.button {
+            button.target = self
+            button.action = #selector(statusItemButtonClicked(sender:))
+            button.sendAction(on: [.leftMouseDown, .leftMouseUp, .rightMouseDown, .rightMouseUp])
+            button.imageScaling = .scaleProportionallyDown
+            button.imagePosition = iconPosition
+        }
+    }
+
+    private func updateImagePosition(for title: String) {
+        guard let button = statusItem?.button else {
+            return
+        }
+        if title.isEmpty {
+            button.imagePosition = .imageOnly
+        } else {
+            button.imagePosition = iconPosition
+        }
+    }
+
+    private func imagePosition(from value: String) -> NSControl.ImagePosition {
+        switch value {
+        case "right":
+            return .imageRight
+        default:
+            return .imageLeft
+        }
+    }
     
     public func destroy(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-        if (trayIcon?.statusItem != nil) {
-            NSStatusBar.system.removeStatusItem((trayIcon?.statusItem)!)
+        if (statusItem != nil) {
+            NSStatusBar.system.removeStatusItem(statusItem!)
         }
-        if (trayIcon != nil) {
-            trayIcon?.removeImage()
-            trayIcon = nil
-        }
+        statusItem = nil
+        trayMenu = nil
+        lastTitle = ""
         result(true)
     }
     
     public func getBounds(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-        let frame = trayIcon?.statusItem?.button?.window?.frame;
+        let frame = statusItem?.button?.window?.frame;
         
         if (frame != nil) {
             let resultData: NSDictionary = [
@@ -141,24 +184,13 @@ public class TrayManagerPlugin: NSObject, FlutterPlugin, NSMenuDelegate {
         let image = NSImage(data: imageData!)
         image!.size = NSSize(width: iconSize, height: iconSize)
         image!.isTemplate = isTemplate
-        
-        if (trayIcon == nil) {
-            trayIcon = TrayIcon()
-            trayIcon?.onTrayIconMouseDown = { () in
-                self.channel.invokeMethod(kEventOnTrayIconMouseDown, arguments: nil, result: nil)
-            }
-            trayIcon?.onTrayIconMouseUp = { () in
-                self.channel.invokeMethod(kEventOnTrayIconMouseUp, arguments: nil, result: nil)
-            }
-            trayIcon?.onTrayIconRightMouseDown = { () in
-                self.channel.invokeMethod(kEventOnTrayIconRightMouseDown, arguments: nil, result: nil)
-            }
-            trayIcon?.onTrayIconRightMouseUp = { () in
-                self.channel.invokeMethod(kEventOnTrayIconRightMouseUp, arguments: nil, result: nil)
-            }
+
+        ensureStatusItem()
+        self.iconPosition = imagePosition(from: iconPosition)
+        if let button = statusItem?.button {
+            button.image = image
         }
-        
-        trayIcon?.setImage(image!, iconPosition)
+        updateImagePosition(for: lastTitle)
         
         result(true)
     }
@@ -166,8 +198,10 @@ public class TrayManagerPlugin: NSObject, FlutterPlugin, NSMenuDelegate {
     public func setIconPosition(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         let args:[String: Any] = call.arguments as! [String: Any]
         let iconPosition: String =  args["iconPosition"] as! String;
-        
-        trayIcon?.setImagePosition(iconPosition)
+
+        ensureStatusItem()
+        self.iconPosition = imagePosition(from: iconPosition)
+        updateImagePosition(for: lastTitle)
         
         result(true)
     }
@@ -175,8 +209,11 @@ public class TrayManagerPlugin: NSObject, FlutterPlugin, NSMenuDelegate {
     public func setToolTip(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         let args:[String: Any] = call.arguments as! [String: Any]
         let toolTip: String =  args["toolTip"] as! String;
-        
-        trayIcon?.setToolTip(toolTip)
+
+        ensureStatusItem()
+        if let button = statusItem?.button {
+            button.toolTip = toolTip
+        }
         
         result(true)
     }
@@ -184,8 +221,21 @@ public class TrayManagerPlugin: NSObject, FlutterPlugin, NSMenuDelegate {
     public func setTitle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         let args:[String: Any] = call.arguments as! [String: Any]
         let title: String =  args["title"] as! String;
-        
-        trayIcon?.setTitle(title)
+
+        ensureStatusItem()
+        if title == lastTitle {
+            result(true)
+            return
+        }
+        lastTitle = title
+        if let button = statusItem?.button {
+            if let attributes = textAttributes {
+                button.attributedTitle = NSAttributedString(string: title, attributes: attributes)
+            } else {
+                button.title = title
+            }
+        }
+        updateImagePosition(for: title)
         
         result(true)
     }
@@ -208,8 +258,8 @@ public class TrayManagerPlugin: NSObject, FlutterPlugin, NSMenuDelegate {
     
     public func popUpContextMenu(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         if (trayMenu != nil) {
-            trayIcon?.statusItem?.menu = trayMenu
-            trayIcon?.statusItem?.button?.performClick(trayIcon)
+            statusItem?.menu = trayMenu
+            statusItem?.button?.performClick(nil)
         }
         result(true)
     }
@@ -217,6 +267,6 @@ public class TrayManagerPlugin: NSObject, FlutterPlugin, NSMenuDelegate {
     // NSMenuDelegate
     
     public func menuDidClose(_ menu: NSMenu) {
-        trayIcon?.statusItem?.menu = nil
+        statusItem?.menu = nil
     }
 }


### PR DESCRIPTION
**Why**
- High CPU/power usage on macOS traced to frequent NSStatusItem redraws in tray.
- Related: https://github.com/chen08209/FlClash/issues/1716

**How**
- Replace custom TrayIcon view with direct NSStatusBarButton usage.
- Cache tray title to avoid redundant updates.
- Adjust icon position based on whether title is empty.

**Tests**
- Not run (not requested).